### PR TITLE
skip users after timeout

### DIFF
--- a/web/bystander/celery.py
+++ b/web/bystander/celery.py
@@ -1,0 +1,7 @@
+from celery import Celery
+
+from .conf import REDIS_HOST
+
+
+app = Celery('tasks', broker="redis://{}:6379/0".format(REDIS_HOST))
+app.autodiscover_tasks(lambda: ['bystander'])

--- a/web/bystander/conf.py
+++ b/web/bystander/conf.py
@@ -1,6 +1,8 @@
 INCOMING_TOKEN = "XXXXXXX"
 OUTGOING_TOKEN = "XXXXXXX"
 EXPIRE_SECONDS = 60 * 60
+TIMEOUT_SECONDS = 2 * 60
+REDIS_HOST = 'redis'
 
 try:
     from .conf_private import *  # noqa

--- a/web/bystander/server.py
+++ b/web/bystander/server.py
@@ -39,14 +39,14 @@ def button():
     if data['token'] != INCOMING_TOKEN:
         abort(401)
 
-    id, requester_id = data['callback_id'].split(':', 1)
+    id = data['callback_id']
     user_id = data['user']['id']
     channel_id = data['channel']['id']
 
     if data['actions'][0]['name'] == "yes":
-        accept_bystander.delay(id, user_id, channel_id, requester_id)
+        accept_bystander.delay(id, user_id, channel_id)
     else:
-        reject_bystander.delay(id, user_id, channel_id, requester_id)
+        reject_bystander.delay(id, user_id, channel_id)
 
     return jsonify({'response_type': "ephemeral",
                     'text': "Thank you for your choice"})


### PR DESCRIPTION
This enables a 2 minute timeout for users who have received the
notification but have not acted on it. The basic idea is we launch a task
with a 2 minute countdown to send the buttons to someone else. In the
meantime we track who the buttons were last sent to, and when the task runs
it checks to see if the first user has in the meantime pressed "Reject". If
everyone is skipped then further action is taken and anyone can press
"Accept". In the future this could be made more efficient.

Also, we make the redis hostname configurable and separate the celery app
from the tasks (so that the tasks can be loaded lazily by celery).